### PR TITLE
Build with rockstar support on Linux

### DIFF
--- a/recipe/detect-rockstar.patch
+++ b/recipe/detect-rockstar.patch
@@ -1,0 +1,52 @@
+From a81652a0000ce8b5505b1aded041383340762505 Mon Sep 17 00:00:00 2001
+From: Corentin Cadiou <corentin.cadiou@cphyc.me>
+Date: Wed, 30 Aug 2023 17:07:40 +0200
+Subject: [PATCH] Automatically detect rockstar when installed in a conda
+ environment
+
+---
+ setup.py | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 2821528..08da046 100644
+--- a/setup.py
++++ b/setup.py
+@@ -78,6 +78,7 @@ def get_version(filename):
+ ]
+ 
+ # ROCKSTAR
++_paths_to_try = []
+ if os.path.exists("rockstar.cfg"):
+     try:
+         rd = open("rockstar.cfg").read().strip()
+@@ -87,7 +88,19 @@ def get_version(filename):
+         print("rockstar-galaxies install in rockstar.cfg and restart.")
+         print("(ex: \"echo '/path/to/rockstar-galaxies' > rockstar.cfg\" )")
+         sys.exit(1)
+-
++    _paths_to_try.append(rd)
++
++if "CONDA_PREFIX" in os.environ:
++    _paths_to_try.append(os.path.join(
++        os.environ["CONDA_PREFIX"],
++        "include",
++        "rockstar-galaxies"
++    ))
++
++for rd in _paths_to_try:
++    if not os.path.exists(rd):
++        continue
++    print(f"BUILDING with ROCKSTAR in {rd}")
+     rockstar_extdir = "yt_astro_analysis/halo_analysis/halo_finding/rockstar"
+     rockstar_extensions = [
+         Extension(
+@@ -108,6 +121,8 @@ def get_version(filename):
+         ext.include_dirs += [rd, os.path.join(rd, "io"), os.path.join(rd, "util")]
+     extensions += rockstar_extensions
+ 
++    break
++
+ 
+ CYTHONIZE_KWARGS = {
+     "compiler_directives": {"language_level": 3},

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,13 +15,14 @@ source:
     - detect-rockstar.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py>=312 or py2k]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - rockstar-galaxies  # [linux]
   host:
     - cython >=0.29.21,<3.0
     - numpy
@@ -33,11 +34,13 @@ requirements:
     - python
     - yt >=4.0.1
     - {{ pin_compatible('numpy') }}
+    - rockstar-galaxies  # [linux]
 
 test:
   imports:
     - yt_astro_analysis
     - yt_astro_analysis.cosmological_observation
+    - yt_astro_analysis.halo_analysis.halo_finding.rockstar.rockstar_interface  # [linux]
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,10 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/yt_astro_analysis-{{ version }}.tar.gz
   sha256: 59307b598be8aab55b94e3b5a3dc185445885006b025fa0da50819e5c45297c0
+  # NOTE: Remove once https://github.com/yt-project/yt_astro_analysis/pull/219 is merged
+  # and shipped in a release.
+  patches:
+    - detect-rockstar.patch
 
 build:
   number: 1


### PR DESCRIPTION
Modifies the feedstock so that it builds with rockstar support on Linux by default.

Requires https://github.com/yt-project/yt_astro_analysis/pull/219 to be merged first.